### PR TITLE
prevent division by zero in bytesPerPacket

### DIFF
--- a/src/main/java/de/maxhenkel/voicechat/voice/client/MicThread.java
+++ b/src/main/java/de/maxhenkel/voicechat/voice/client/MicThread.java
@@ -133,7 +133,7 @@ public class MicThread extends Thread {
     private void sendAudioPacket(byte[] data) {
         int dataLength = AudioChannelConfig.getDataLength();
         int packetAmount = (int) Math.ceil((double) data.length / (double) dataLength);
-        int bytesPerPacket = data.length / packetAmount;
+        int bytesPerPacket = packetAmount == 0 ? 0 : data.length / packetAmount;
         if (bytesPerPacket % 2 == 1) {
             bytesPerPacket--;
         }


### PR DESCRIPTION
I believe this should prevent the following error from happening when using voice activation in simple voice chat.
```
[17Feb2021 16:51:36.980] [MicrophoneThread/INFO] [STDERR/]: [java.lang.ThreadGroup:uncaughtException:1052]: java.lang.ArithmeticException: / by zero
[17Feb2021 16:51:36.980] [MicrophoneThread/INFO] [STDERR/]: [java.lang.ThreadGroup:uncaughtException:1052]: 	at de.maxhenkel.voicechat.voice.client.MicThread.sendAudioPacket(MicThread.java:136)
[17Feb2021 16:51:36.980] [MicrophoneThread/INFO] [STDERR/]: [java.lang.ThreadGroup:uncaughtException:1052]: 	at de.maxhenkel.voicechat.voice.client.MicThread.voice(MicThread.java:93)
[17Feb2021 16:51:36.980] [MicrophoneThread/INFO] [STDERR/]: [java.lang.ThreadGroup:uncaughtException:1052]: 	at de.maxhenkel.voicechat.voice.client.MicThread.run(MicThread.java:39)
```