### PR TITLE
Fix transparent skin rendering in group list

### DIFF
--- a/src/main/java/de/maxhenkel/voicechat/gui/widgets/CreateGroupList.java
+++ b/src/main/java/de/maxhenkel/voicechat/gui/widgets/CreateGroupList.java
@@ -91,6 +91,8 @@ public class CreateGroupList extends WidgetBase {
                 matrixStack.pushPose();
                 RenderSystem.setShader(GameRenderer::getPositionTexShader);
                 RenderSystem.setShaderColor(1F, 1F, 1F, 1F);
+                RenderSystem.enableBlend();
+                RenderSystem.defaultBlendFunc();
                 RenderSystem.setShaderTexture(0, SkinUtils.getSkin(state.getGameProfile().getId()));
                 matrixStack.translate(headPosX, headPosY, 0);
                 Screen.blit(matrixStack, 0, 0, 8, 8, 8, 8, 64, 64);

--- a/src/main/java/de/maxhenkel/voicechat/gui/widgets/GroupList.java
+++ b/src/main/java/de/maxhenkel/voicechat/gui/widgets/GroupList.java
@@ -96,6 +96,8 @@ public class GroupList extends WidgetBase {
             matrixStack.pushPose();
             RenderSystem.setShader(GameRenderer::getPositionTexShader);
             RenderSystem.setShaderColor(1F, 1F, 1F, 1F);
+            RenderSystem.enableBlend();
+            RenderSystem.defaultBlendFunc();
             RenderSystem.setShaderTexture(0, SkinUtils.getSkin(state.getGameProfile().getId()));
             matrixStack.translate(guiLeft + 3, startY + 3, 0);
             matrixStack.scale(2F, 2F, 1F);

--- a/src/main/java/de/maxhenkel/voicechat/voice/client/GroupChatManager.java
+++ b/src/main/java/de/maxhenkel/voicechat/voice/client/GroupChatManager.java
@@ -52,6 +52,8 @@ public class GroupChatManager {
             }
             RenderSystem.setShader(GameRenderer::getPositionTexShader);
             RenderSystem.setShaderColor(1F, 1F, 1F, 1F);
+            RenderSystem.enableBlend();
+            RenderSystem.defaultBlendFunc();
             RenderSystem.setShaderTexture(0, SkinUtils.getSkin(state.getGameProfile().getId()));
             Screen.blit(matrixStack, 1, 1, 8, 8, 8, 8, 64, 64);
             Screen.blit(matrixStack, 1, 1, 40, 8, 8, 8, 64, 64);


### PR DESCRIPTION
As title said, You can reproduce this issue by typing some text and then open chat.

Before :
![2021-07-11_20 14 47](https://user-images.githubusercontent.com/6128413/125196587-a95df680-e284-11eb-902c-52e6483056bd.png)

After :
![2021-07-11_20 13 12](https://user-images.githubusercontent.com/6128413/125196593-af53d780-e284-11eb-9bd8-90d465a63d06.png)
