### PR TITLE
Improve the structure of microphone permission-checking code on macOS

### DIFF
--- a/common/src/main/java/de/maxhenkel/voicechat/VoicechatClient.java
+++ b/common/src/main/java/de/maxhenkel/voicechat/VoicechatClient.java
@@ -5,6 +5,7 @@ import de.maxhenkel.voicechat.config.ClientConfig;
 import de.maxhenkel.voicechat.config.PlayerVolumeConfig;
 import de.maxhenkel.voicechat.intercompatibility.ClientCompatibilityManager;
 import de.maxhenkel.voicechat.macos.PermissionCheck;
+import de.maxhenkel.voicechat.macos.jna.avfoundation.AVAuthorizationStatus;
 import de.maxhenkel.voicechat.resourcepacks.VoiceChatResourcePack;
 import de.maxhenkel.voicechat.voice.client.ClientManager;
 import de.maxhenkel.voicechat.voice.client.MacOSUtils;
@@ -48,9 +49,9 @@ public abstract class VoicechatClient {
 
         if (Platform.isMac() && VoicechatClient.CLIENT_CONFIG.macosMicrophoneWorkaround.get()) {
             Voicechat.LOGGER.info("Running MacOS microphone permission check");
-            PermissionCheck.AVAuthorizationStatus status = PermissionCheck.getMicrophonePermissions();
+            AVAuthorizationStatus status = PermissionCheck.getMicrophonePermissions();
             Voicechat.LOGGER.info("MacOS microphone permission: {}", status.name());
-            if (!status.equals(PermissionCheck.AVAuthorizationStatus.AUTHORIZED)) {
+            if (!status.equals(AVAuthorizationStatus.AUTHORIZED)) {
                 MacOSUtils.checkPermissionInSeparateProcess();
             }
         }

--- a/macos/readme.md
+++ b/macos/readme.md
@@ -23,6 +23,9 @@ Note that this might cause other issues with your launcher, so use this at your 
 You can revert these changes by reinstalling the launcher.
 
 After restarting the launcher, Minecraft should now ask for microphone access.
+- If the launcher doesn't ask for Microphone access after patching it in the GUI, run the following command in a
+  Terminal window:
+  `codesign --force --deep --sign - <your-application>`.
 
 ### How to patch your launcher
 

--- a/macos/readme.md
+++ b/macos/readme.md
@@ -23,9 +23,8 @@ Note that this might cause other issues with your launcher, so use this at your 
 You can revert these changes by reinstalling the launcher.
 
 After restarting the launcher, Minecraft should now ask for microphone access.
-- If the launcher doesn't ask for Microphone access after patching it in the GUI, run the following command in a
-  Terminal window:
-  `codesign --force --deep --sign - <your-application>`.
+> If the launcher doesn't ask for Microphone access after patching it in the GUI, run the following command in a Terminal window:
+`codesign --force --deep --sign - <your-application>`.
 
 ### How to patch your launcher
 

--- a/macos/src/main/java/de/maxhenkel/voicechat/macos/Main.java
+++ b/macos/src/main/java/de/maxhenkel/voicechat/macos/Main.java
@@ -1,11 +1,11 @@
 package de.maxhenkel.voicechat.macos;
 
 import com.sun.jna.Platform;
+import de.maxhenkel.voicechat.macos.jna.avfoundation.AVAuthorizationStatus;
 
-import java.awt.GraphicsEnvironment;
+import java.awt.*;
 
 public class Main {
-
     public static void main(String[] args) {
         if (!Platform.isMac()) {
             System.out.println("You are not on MacOS");
@@ -25,24 +25,30 @@ public class Main {
     }
 
     private static void request() {
-        PermissionCheck.AVAuthorizationStatus status = PermissionCheck.getMicrophonePermissions();
-        if (status.equals(PermissionCheck.AVAuthorizationStatus.NOT_DETERMINED)) {
+        AVAuthorizationStatus status = PermissionCheck.getMicrophonePermissions();
+        if (status.equals(AVAuthorizationStatus.NOT_DETERMINED)) {
             PermissionCheck.requestMicrophonePermissions();
         }
+
         int i = 0;
-        while (status.equals(PermissionCheck.AVAuthorizationStatus.NOT_DETERMINED)) {
+        while (status.equals(AVAuthorizationStatus.NOT_DETERMINED)) {
             status = PermissionCheck.getMicrophonePermissions();
             try {
                 Thread.sleep(500);
             } catch (InterruptedException e) {
                 e.printStackTrace();
             }
+
             if (i < 10) {
                 i++;
             } else {
                 System.exit(99);
                 break;
             }
+        }
+
+        if (status != AVAuthorizationStatus.AUTHORIZED) {
+            System.err.println("Simple Voice Chat is unable to use the Microphone. Status: " + status);
         }
     }
 
@@ -55,5 +61,4 @@ public class Main {
 
         new MacosFrame();
     }
-
 }

--- a/macos/src/main/java/de/maxhenkel/voicechat/macos/PermissionCheck.java
+++ b/macos/src/main/java/de/maxhenkel/voicechat/macos/PermissionCheck.java
@@ -1,14 +1,11 @@
 package de.maxhenkel.voicechat.macos;
 
-import com.sun.jna.Library;
-import com.sun.jna.Native;
-import com.sun.jna.NativeLong;
-import com.sun.jna.Pointer;
-
-import java.nio.charset.StandardCharsets;
-import java.util.Map;
+import de.maxhenkel.voicechat.macos.jna.avfoundation.AVAuthorizationStatus;
+import de.maxhenkel.voicechat.macos.jna.avfoundation.AVCaptureDevice;
+import de.maxhenkel.voicechat.macos.jna.foundation.NSString;
 
 public class PermissionCheck {
+    private static final NSString AVMediaTypeAudio = new NSString("soun");
 
     public static void requestMicrophonePermissions() {
         checkMicrophonePermissions(true);
@@ -22,84 +19,12 @@ public class PermissionCheck {
         if (!VersionCheck.isMinimumVersion(10, 14, 0)) {
             return AVAuthorizationStatus.AUTHORIZED;
         }
-        Pointer classPointerAVCaptureDevice = AVFoundationLibrary.INSTANCE.objc_getClass("AVCaptureDevice");
-        Pointer pointerGetAuthorizationStatus = AVFoundationLibrary.INSTANCE.sel_registerName("authorizationStatusForMediaType:");
-        Pointer pointerRequestAccessForMediaType = AVFoundationLibrary.INSTANCE.sel_registerName("requestAccessForMediaType:completionHandler:");
 
-        Pointer classPointerNSString = FoundationLibrary.INSTANCE.objc_getClass("NSString");
-        Pointer pointerCreateNSStringWithUTF8CString = FoundationLibrary.INSTANCE.sel_registerName("stringWithUTF8String:");
-        Pointer pointerAudioRequestConstant = FoundationLibrary.INSTANCE.objc_msgSend(classPointerNSString, pointerCreateNSStringWithUTF8CString, "soun");
-
-        NativeLong permissionEnum = AVFoundationLibrary.INSTANCE.objc_msgSend(classPointerAVCaptureDevice, pointerGetAuthorizationStatus, pointerAudioRequestConstant);
-
-        AVAuthorizationStatus avAuthorizationStatus = AVAuthorizationStatus.byValue(permissionEnum);
-
-        if (requestIfNeeded && avAuthorizationStatus.equals(AVAuthorizationStatus.NOT_DETERMINED)) {
-            AVFoundationLibrary.INSTANCE.objc_msgSend(classPointerAVCaptureDevice, pointerRequestAccessForMediaType, pointerAudioRequestConstant, null);
+        var status = AVCaptureDevice.getAuthorizationStatus(AVMediaTypeAudio);
+        if (requestIfNeeded && status == AVAuthorizationStatus.NOT_DETERMINED) {
+            AVCaptureDevice.requestAccessForMediaType(AVMediaTypeAudio);
         }
-        return avAuthorizationStatus;
+
+        return status;
     }
-
-    public enum AVAuthorizationStatus {
-        NOT_DETERMINED(0),
-        RESTRICTED(1),
-        DENIED(2),
-        AUTHORIZED(3);
-
-        private final int value;
-
-        AVAuthorizationStatus(int value) {
-            this.value = value;
-        }
-
-        public int getValue() {
-            return value;
-        }
-
-        public static AVAuthorizationStatus byValue(NativeLong value) {
-            return byValue(value.longValue());
-        }
-
-        public static AVAuthorizationStatus byValue(long value) {
-            return byValue((int) value);
-        }
-
-        public static AVAuthorizationStatus byValue(int value) {
-            for (AVAuthorizationStatus status : values()) {
-                if (status.getValue() == value) {
-                    return status;
-                }
-            }
-            return null;
-        }
-    }
-
-    private interface AVFoundationLibrary extends Library {
-        AVFoundationLibrary INSTANCE = Native.load("AVFoundation", AVFoundationLibrary.class, Map.of(Library.OPTION_STRING_ENCODING, StandardCharsets.UTF_8.name()));
-
-        // https://developer.apple.com/documentation/objectivec/1418952-objc_getclass?language=objc
-        Pointer objc_getClass(String className);
-
-        // https://developer.apple.com/documentation/objectivec/1418557-sel_registername?language=objc
-        Pointer sel_registerName(String selectorName);
-
-        // https://developer.apple.com/documentation/objectivec/1456712-objc_msgsend?language=objc
-        NativeLong objc_msgSend(Pointer receiver, Pointer selector, Pointer pointer);
-
-        NativeLong objc_msgSend(Pointer receiver, Pointer selector, Pointer pointer1, Pointer pointer2);
-    }
-
-    private interface FoundationLibrary extends Library {
-        FoundationLibrary INSTANCE = Native.load("Foundation", FoundationLibrary.class, Map.of(Library.OPTION_STRING_ENCODING, StandardCharsets.UTF_8.name()));
-
-        // https://developer.apple.com/documentation/objectivec/1418952-objc_getclass?language=objc
-        Pointer objc_getClass(String className);
-
-        // https://developer.apple.com/documentation/objectivec/1418557-sel_registername?language=objc
-        Pointer sel_registerName(String selectorName);
-
-        // https://developer.apple.com/documentation/objectivec/1456712-objc_msgsend?language=objc
-        Pointer objc_msgSend(Pointer receiver, Pointer selector, String name);
-    }
-
 }

--- a/macos/src/main/java/de/maxhenkel/voicechat/macos/jna/avfoundation/AVAuthorizationStatus.java
+++ b/macos/src/main/java/de/maxhenkel/voicechat/macos/jna/avfoundation/AVAuthorizationStatus.java
@@ -1,0 +1,37 @@
+package de.maxhenkel.voicechat.macos.jna.avfoundation;
+
+import com.sun.jna.NativeLong;
+
+public enum AVAuthorizationStatus {
+    NOT_DETERMINED(0),
+    RESTRICTED(1),
+    DENIED(2),
+    AUTHORIZED(3);
+
+    private final int value;
+
+    AVAuthorizationStatus(int value) {
+        this.value = value;
+    }
+
+    public static AVAuthorizationStatus byValue(NativeLong value) {
+        return byValue(value.longValue());
+    }
+
+    public static AVAuthorizationStatus byValue(long value) {
+        return byValue((int) value);
+    }
+
+    public static AVAuthorizationStatus byValue(int value) {
+        for (AVAuthorizationStatus status : values()) {
+            if (status.getValue() == value) {
+                return status;
+            }
+        }
+        return null;
+    }
+
+    public int getValue() {
+        return value;
+    }
+}

--- a/macos/src/main/java/de/maxhenkel/voicechat/macos/jna/avfoundation/AVCaptureDevice.java
+++ b/macos/src/main/java/de/maxhenkel/voicechat/macos/jna/avfoundation/AVCaptureDevice.java
@@ -12,18 +12,33 @@ public class AVCaptureDevice extends NSObject {
     // [AVCaptureDevice authorizationStatusForMediaType:]; -> https://developer.apple.com/documentation/avfoundation/avcapturedevice/1624613-authorizationstatusformediatype?language=objc
     private static final Pointer authorizationStatusForMediaTypeSelector = AVFoundation.INSTANCE.sel_registerName("authorizationStatusForMediaType:");
 
-    // [AVCaptureDevice requestAccessForMediaType:completion:]; ->
+    // [AVCaptureDevice requestAccessForMediaType:completion:]; -> https://developer.apple.com/documentation/avfoundation/avcapturedevice/1624584-requestaccessformediatype?language=objc
     private static final Pointer requestAccessForMediaTypeSelector = AVFoundation.INSTANCE.sel_registerName("requestAccessForMediaType:completionHandler:");
 
-    public AVCaptureDevice(NativeLong id) {
-        super(id);
+    /**
+     * Unused constructor, but required for inheriting our {@link NSObject} class.
+     */
+    public AVCaptureDevice() {
+        super(new NativeLong(-1L));
     }
 
+    /**
+     * Returns the authorization status for a specified media type.
+     *
+     * @param mediaType A media type constant, i.e. "soun" for AVMediaTypeAudio.
+     * @return DENIED if the user has explicitly denied permission for the specified media type, ACCEPTED if permission has been granted, or NOT_DETERMINED if the user has not yet made a choice regarding whether permission has been granted.
+     */
     public static AVAuthorizationStatus getAuthorizationStatus(NSString mediaType) {
         NativeLong permissionEnum = AVFoundation.INSTANCE.objc_msgSend(nativeClass, authorizationStatusForMediaTypeSelector, mediaType.getId());
         return AVAuthorizationStatus.byValue(permissionEnum);
     }
 
+    /**
+     * Requests the user's permission, if needed, for recording a specified media type.
+     *
+     * @param mediaType A media type constant, i.e. "soun" for AVMediaTypeAudio.
+     * @see <a href="https://developer.apple.com/documentation/avfoundation/avcapturedevice/1624584-requestaccessformediatype?language=objc"">...</a>
+     */
     public static void requestAccessForMediaType(NSString mediaType) {
         AVFoundation.INSTANCE.objc_msgSend(nativeClass, requestAccessForMediaTypeSelector, mediaType.getId(), null);
     }

--- a/macos/src/main/java/de/maxhenkel/voicechat/macos/jna/avfoundation/AVCaptureDevice.java
+++ b/macos/src/main/java/de/maxhenkel/voicechat/macos/jna/avfoundation/AVCaptureDevice.java
@@ -1,0 +1,30 @@
+package de.maxhenkel.voicechat.macos.jna.avfoundation;
+
+import com.sun.jna.NativeLong;
+import com.sun.jna.Pointer;
+import de.maxhenkel.voicechat.macos.jna.foundation.NSObject;
+import de.maxhenkel.voicechat.macos.jna.foundation.NSString;
+
+public class AVCaptureDevice extends NSObject {
+    // AVCaptureDevice -> https://developer.apple.com/documentation/avfoundation/avcapturedevice?language=objc
+    private static final Pointer nativeClass = AVFoundation.INSTANCE.objc_getClass("AVCaptureDevice");
+
+    // [AVCaptureDevice authorizationStatusForMediaType:]; -> https://developer.apple.com/documentation/avfoundation/avcapturedevice/1624613-authorizationstatusformediatype?language=objc
+    private static final Pointer authorizationStatusForMediaTypeSelector = AVFoundation.INSTANCE.sel_registerName("authorizationStatusForMediaType:");
+
+    // [AVCaptureDevice requestAccessForMediaType:completion:]; ->
+    private static final Pointer requestAccessForMediaTypeSelector = AVFoundation.INSTANCE.sel_registerName("requestAccessForMediaType:completionHandler:");
+
+    public AVCaptureDevice(NativeLong id) {
+        super(id);
+    }
+
+    public static AVAuthorizationStatus getAuthorizationStatus(NSString mediaType) {
+        NativeLong permissionEnum = AVFoundation.INSTANCE.objc_msgSend(nativeClass, authorizationStatusForMediaTypeSelector, mediaType.getId());
+        return AVAuthorizationStatus.byValue(permissionEnum);
+    }
+
+    public static void requestAccessForMediaType(NSString mediaType) {
+        AVFoundation.INSTANCE.objc_msgSend(nativeClass, requestAccessForMediaTypeSelector, mediaType.getId(), null);
+    }
+}

--- a/macos/src/main/java/de/maxhenkel/voicechat/macos/jna/avfoundation/AVFoundation.java
+++ b/macos/src/main/java/de/maxhenkel/voicechat/macos/jna/avfoundation/AVFoundation.java
@@ -15,10 +15,8 @@ public interface AVFoundation extends Library {
     Pointer sel_registerName(String selectorName);
 
     // https://developer.apple.com/documentation/objectivec/1456712-objc_msgsend?language=objc
-    NativeLong objc_msgSend(Pointer receiver, Pointer selector, Pointer pointer);
-
-    // https://developer.apple.com/documentation/objectivec/1456712-objc_msgsend?language=objc
     NativeLong objc_msgSend(Pointer receiver, Pointer selector, NativeLong arg1);
 
+    // https://developer.apple.com/documentation/objectivec/1456712-objc_msgsend?language=objc
     NativeLong objc_msgSend(Pointer receiver, Pointer selector, NativeLong arg1, Pointer arg2);
 }

--- a/macos/src/main/java/de/maxhenkel/voicechat/macos/jna/avfoundation/AVFoundation.java
+++ b/macos/src/main/java/de/maxhenkel/voicechat/macos/jna/avfoundation/AVFoundation.java
@@ -1,0 +1,24 @@
+package de.maxhenkel.voicechat.macos.jna.avfoundation;
+
+import com.sun.jna.Library;
+import com.sun.jna.Native;
+import com.sun.jna.NativeLong;
+import com.sun.jna.Pointer;
+
+public interface AVFoundation extends Library {
+    AVFoundation INSTANCE = Native.load("AVFoundation", AVFoundation.class);
+
+    // https://developer.apple.com/documentation/objectivec/1418952-objc_getclass?language=objc
+    Pointer objc_getClass(String className);
+
+    // https://developer.apple.com/documentation/objectivec/1418557-sel_registername?language=objc
+    Pointer sel_registerName(String selectorName);
+
+    // https://developer.apple.com/documentation/objectivec/1456712-objc_msgsend?language=objc
+    NativeLong objc_msgSend(Pointer receiver, Pointer selector, Pointer pointer);
+
+    // https://developer.apple.com/documentation/objectivec/1456712-objc_msgsend?language=objc
+    NativeLong objc_msgSend(Pointer receiver, Pointer selector, NativeLong arg1);
+
+    NativeLong objc_msgSend(Pointer receiver, Pointer selector, NativeLong arg1, Pointer arg2);
+}

--- a/macos/src/main/java/de/maxhenkel/voicechat/macos/jna/foundation/Foundation.java
+++ b/macos/src/main/java/de/maxhenkel/voicechat/macos/jna/foundation/Foundation.java
@@ -1,0 +1,31 @@
+package de.maxhenkel.voicechat.macos.jna.foundation;
+
+import com.sun.jna.Library;
+import com.sun.jna.Native;
+import com.sun.jna.NativeLong;
+import com.sun.jna.Pointer;
+
+public interface Foundation extends Library {
+    public static final Foundation INSTANCE = Native.load("Foundation", Foundation.class);
+
+    // void objc_msgSend(*); -> https://developer.apple.com/documentation/objectivec/1456712-objc_msgsend?language=objc
+    NativeLong objc_msgSend(Pointer receiver, Pointer selector);
+
+    // void objc_msgSend(*); -> https://developer.apple.com/documentation/objectivec/1456712-objc_msgsend?language=objc
+    NativeLong objc_msgSend(NativeLong receiver, Pointer selector);
+
+    // void objc_msgSend(*); -> https://developer.apple.com/documentation/objectivec/1456712-objc_msgsend?language=objc
+    NativeLong objc_msgSend(NativeLong receiver, Pointer selector, NativeLong arg1, NativeLong arg2);
+
+    // void objc_msgSend(*); -> https://developer.apple.com/documentation/objectivec/1456712-objc_msgsend?language=objc
+    NativeLong objc_msgSend(Pointer receiver, Pointer selector, String arg1);
+
+    // void objc_msgSend(*); -> https://developer.apple.com/documentation/objectivec/1456712-objc_msgsend?language=objc
+    NativeLong objc_msgSend(NativeLong receiver, Pointer selector, NativeLong arg1);
+
+    // id objc_getClass(const char* name); -> https://developer.apple.com/documentation/objectivec/1418952-objc_getclass?language=objc
+    Pointer objc_getClass(String className);
+
+    // SEL sel_registerName(const char* name); -> https://developer.apple.com/documentation/objectivec/1418557-sel_registername?language=objc
+    Pointer sel_registerName(String selectorName);
+}

--- a/macos/src/main/java/de/maxhenkel/voicechat/macos/jna/foundation/Foundation.java
+++ b/macos/src/main/java/de/maxhenkel/voicechat/macos/jna/foundation/Foundation.java
@@ -6,22 +6,13 @@ import com.sun.jna.NativeLong;
 import com.sun.jna.Pointer;
 
 public interface Foundation extends Library {
-    public static final Foundation INSTANCE = Native.load("Foundation", Foundation.class);
-
-    // void objc_msgSend(*); -> https://developer.apple.com/documentation/objectivec/1456712-objc_msgsend?language=objc
-    NativeLong objc_msgSend(Pointer receiver, Pointer selector);
+    Foundation INSTANCE = Native.load("Foundation", Foundation.class);
 
     // void objc_msgSend(*); -> https://developer.apple.com/documentation/objectivec/1456712-objc_msgsend?language=objc
     NativeLong objc_msgSend(NativeLong receiver, Pointer selector);
 
     // void objc_msgSend(*); -> https://developer.apple.com/documentation/objectivec/1456712-objc_msgsend?language=objc
-    NativeLong objc_msgSend(NativeLong receiver, Pointer selector, NativeLong arg1, NativeLong arg2);
-
-    // void objc_msgSend(*); -> https://developer.apple.com/documentation/objectivec/1456712-objc_msgsend?language=objc
     NativeLong objc_msgSend(Pointer receiver, Pointer selector, String arg1);
-
-    // void objc_msgSend(*); -> https://developer.apple.com/documentation/objectivec/1456712-objc_msgsend?language=objc
-    NativeLong objc_msgSend(NativeLong receiver, Pointer selector, NativeLong arg1);
 
     // id objc_getClass(const char* name); -> https://developer.apple.com/documentation/objectivec/1418952-objc_getclass?language=objc
     Pointer objc_getClass(String className);

--- a/macos/src/main/java/de/maxhenkel/voicechat/macos/jna/foundation/NSObject.java
+++ b/macos/src/main/java/de/maxhenkel/voicechat/macos/jna/foundation/NSObject.java
@@ -1,0 +1,40 @@
+package de.maxhenkel.voicechat.macos.jna.foundation;
+
+import com.sun.jna.NativeLong;
+import com.sun.jna.Pointer;
+
+/**
+ * A reference to an NSObject, which is holds an 'identifier' (a reference) to a specific object
+ */
+public class NSObject {
+    private static final NativeLong nullPointer = new NativeLong(0L);
+
+    // [NSObject release]; -> https://developer.apple.com/documentation/objectivec/1418956-nsobject/1571957-release
+    private static final Pointer releaseSelector = Foundation.INSTANCE.sel_registerName("release");
+
+    protected final NativeLong id;
+
+    public NSObject(NativeLong id) {
+        this.id = id;
+    }
+
+    /**
+     * Returns the identifier for this NSObject
+     */
+    public final NativeLong getId() {
+        return id;
+    }
+
+    /**
+     * Since we don't have ARC, we need to call this manually at times.
+     * <p>
+     * https://developer.apple.com/documentation/objectivec/1418956-nsobject/1571957-release
+     */
+    public void release() {
+        Foundation.INSTANCE.objc_msgSend(id, releaseSelector);
+    }
+
+    public boolean isNull() {
+        return id.equals(nullPointer);
+    }
+}

--- a/macos/src/main/java/de/maxhenkel/voicechat/macos/jna/foundation/NSString.java
+++ b/macos/src/main/java/de/maxhenkel/voicechat/macos/jna/foundation/NSString.java
@@ -1,0 +1,61 @@
+package de.maxhenkel.voicechat.macos.jna.foundation;
+
+import com.sun.jna.NativeLong;
+import com.sun.jna.Pointer;
+import com.sun.jna.platform.mac.CoreFoundation;
+
+/**
+ * A reference to a NSString object, which encapsulates a CFString reference.
+ */
+public class NSString extends NSObject {
+    // NSString -> https://developer.apple.com/documentation/foundation/nsstring?language=objc
+    private static final Pointer nativeClass = Foundation.INSTANCE.objc_getClass("NSString");
+
+    // [NSString stringWithUTF8String:]; -> https://developer.apple.com/documentation/foundation/nsstring/1497379-stringwithutf8string?language=objc
+    private static final Pointer stringWithUTF8StringSelector = Foundation.INSTANCE.sel_registerName("stringWithUTF8String:");
+
+    /**
+     * Creates a reference to a NSString object, which encapsulates a CFString reference.
+     */
+    public NSString(String javaString) {
+        super(getNativeString(javaString));
+    }
+
+    /**
+     * Wraps a reference to a NSString object, which encapsulates a CFString reference.
+     */
+    public NSString(NativeLong id) {
+        super(id);
+    }
+
+    /**
+     * Converts a Java {@link String} to a native string
+     *
+     * @param javaString the string to convert
+     * @return a native string pointer
+     */
+    private static NativeLong getNativeString(String javaString) {
+        return Foundation.INSTANCE.objc_msgSend(nativeClass, stringWithUTF8StringSelector, javaString);
+    }
+
+    @Override
+    public String toString() {
+        return getJVMString();
+    }
+
+    /**
+     * Returns a Java {@link String} from an NSString instance
+     *
+     * @return the NSString converted to String
+     */
+    public String getJVMString() {
+        return getCFStringRef().stringValue();
+    }
+
+    /**
+     * Gets a CFString reference to the NSString's pointer
+     */
+    public CoreFoundation.CFStringRef getCFStringRef() {
+        return new CoreFoundation.CFStringRef(new Pointer(getId().longValue()));
+    }
+}


### PR DESCRIPTION
This pull request improves readability of code in the `macos` submodule.

Prior to this, we did a lot of direct `objc_msgSend`, `objc_getClass` and other various Foundation library calls without much explanation. This bunch of commits adds 'dummy classes' to mask these calls, thus making the code more readable and (hopefully) easier to maintain! :tada:

I've tested it on my M1 Mac under x86_64 emulation and under native aarch64 execution, both work perfectly without any issues.