### PR TITLE
Delayed ServerVoiceEvents#initializePlayerConnection

### DIFF
--- a/bukkit/src/main/java/de/maxhenkel/voicechat/voice/server/ServerVoiceEvents.java
+++ b/bukkit/src/main/java/de/maxhenkel/voicechat/voice/server/ServerVoiceEvents.java
@@ -54,7 +54,9 @@ public class ServerVoiceEvents implements Listener {
             Voicechat.LOGGER.warn("Connected client {} has incompatible voice chat version (server={}, client={})", player.getName(), Voicechat.COMPATIBILITY_VERSION, packet.getCompatibilityVersion());
             NetManager.sendMessage(player, getIncompatibleMessage(packet.getCompatibilityVersion()));
         } else {
-            initializePlayerConnection(player);
+			Bukkit.getScheduler().runTaskLater(Voicechat.INSTANCE, () -> {
+				initializePlayerConnection(player);
+			}, 20 * 5);
         }
     }
 


### PR DESCRIPTION
Delayed ServerVoiceEvents#initializePlayerConnection by 5 seconds to ensure the player is really connected and ready to go before sending the secret.

As far as I used the plugin when the latency with the server isn't consistent or the server has custom systems that fire on player join, the packet is incapable to arrive and the client will not connect. 

So, delaying by 5 seconds is enough to, for example, send a client-bound packet to load a resource pack. 

Best regards,
Blacky.