### PR TITLE
Load server config before server starts

### DIFF
--- a/fabric/src/main/java/de/maxhenkel/voicechat/FabricVoicechatMod.java
+++ b/fabric/src/main/java/de/maxhenkel/voicechat/FabricVoicechatMod.java
@@ -3,15 +3,13 @@ package de.maxhenkel.voicechat;
 import de.maxhenkel.configbuilder.ConfigBuilder;
 import de.maxhenkel.voicechat.config.FabricServerConfig;
 import net.fabricmc.api.ModInitializer;
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
+import net.fabricmc.loader.api.FabricLoader;
 
 public class FabricVoicechatMod extends Voicechat implements ModInitializer {
 
     @Override
     public void onInitialize() {
-        ServerLifecycleEvents.SERVER_STARTED.register(server -> {
-            SERVER_CONFIG = ConfigBuilder.build(server.getServerDirectory().toPath().resolve("config").resolve(MODID).resolve("voicechat-server.properties"), true, FabricServerConfig::new);
-        });
+        SERVER_CONFIG = ConfigBuilder.build(FabricLoader.getInstance().getConfigDir().resolve(MODID).resolve("voicechat-server.properties"), true, FabricServerConfig::new);
 
         initialize();
     }

--- a/quilt/src/main/java/de/maxhenkel/voicechat/QuiltVoicechatMod.java
+++ b/quilt/src/main/java/de/maxhenkel/voicechat/QuiltVoicechatMod.java
@@ -3,16 +3,14 @@ package de.maxhenkel.voicechat;
 import de.maxhenkel.configbuilder.ConfigBuilder;
 import de.maxhenkel.voicechat.config.QuiltServerConfig;
 import org.quiltmc.loader.api.ModContainer;
+import org.quiltmc.loader.api.QuiltLoader;
 import org.quiltmc.qsl.base.api.entrypoint.ModInitializer;
-import org.quiltmc.qsl.lifecycle.api.event.ServerLifecycleEvents;
 
 public class QuiltVoicechatMod extends Voicechat implements ModInitializer {
 
     @Override
     public void onInitialize(ModContainer mod) {
-        ServerLifecycleEvents.READY.register(server -> {
-            SERVER_CONFIG = ConfigBuilder.build(server.getServerDirectory().toPath().resolve("config").resolve(MODID).resolve("voicechat-server.properties"), true, QuiltServerConfig::new);
-        });
+        SERVER_CONFIG = ConfigBuilder.build(QuiltLoader.getConfigDir().resolve(MODID).resolve("voicechat-server.properties"), true, QuiltServerConfig::new);
 
         initialize();
     }


### PR DESCRIPTION
The reason I make this PR is because this causes a compatability issue with a mod that I maintain: [issue here](https://github.com/Super-Santa/EssentialAddons/issues/49).

TLDR: My mod allows you to let 'fake players' (which are commonly used for loading farms and such) automatically join the game when the server boots, this happens after the worlds have been loaded (before the Fabric/Quilt event you guys use). This means that `VoiceChat.SERVER_CONFIG` is still `null` and you guys hook into player join and use `VoiceChat.SERVER_CONFIG` which in this case throws a NPE.

I have tried to make the fake players join after you have initialised your config however, I ran into another weird issue so I thought it would just be simpler to make a small PR.

From what I see the reason for using the event was to get a reference to the server and use that to get the config directory, but this can be done through other means allowing for it to be initialised earlier preventing the conflict.
