### PR TITLE
fix permission prefix on fabric/quilt

### DIFF
--- a/fabric/src/main/java/de/maxhenkel/voicechat/permission/FabricPermissionManager.java
+++ b/fabric/src/main/java/de/maxhenkel/voicechat/permission/FabricPermissionManager.java
@@ -13,7 +13,7 @@ public class FabricPermissionManager extends PermissionManager {
             @Override
             public boolean hasPermission(ServerPlayer player) {
                 if (isFabricPermissionsAPILoaded()) {
-                    return Permissions.check(player, node, type.hasPermission(player));
+                    return Permissions.check(player, modId + '.' + node, type.hasPermission(player));
                 }
                 return type.hasPermission(player);
             }

--- a/fabric/src/main/java/de/maxhenkel/voicechat/permission/FabricPermissionManager.java
+++ b/fabric/src/main/java/de/maxhenkel/voicechat/permission/FabricPermissionManager.java
@@ -13,7 +13,7 @@ public class FabricPermissionManager extends PermissionManager {
             @Override
             public boolean hasPermission(ServerPlayer player) {
                 if (isFabricPermissionsAPILoaded()) {
-                    return Permissions.check(player, modId + '.' + node, type.hasPermission(player));
+                    return Permissions.check(player, modId + "." + node, type.hasPermission(player));
                 }
                 return type.hasPermission(player);
             }

--- a/quilt/src/main/java/de/maxhenkel/voicechat/permission/QuiltPermissionManager.java
+++ b/quilt/src/main/java/de/maxhenkel/voicechat/permission/QuiltPermissionManager.java
@@ -13,7 +13,7 @@ public class QuiltPermissionManager extends PermissionManager {
             @Override
             public boolean hasPermission(ServerPlayer player) {
                 if (isFabricPermissionsAPILoaded()) {
-                    return Permissions.check(player, node, type.hasPermission(player));
+                    return Permissions.check(player, modId + "." + node, type.hasPermission(player));
                 }
                 return type.hasPermission(player);
             }


### PR DESCRIPTION
the required permissions on fabric (and quilt aswell) didn't include the `voicechat.` prefix.
this fixes said issue.