### PR TITLE
Improve freecam support

### DIFF
--- a/common/src/main/java/de/maxhenkel/voicechat/config/ClientConfig.java
+++ b/common/src/main/java/de/maxhenkel/voicechat/config/ClientConfig.java
@@ -190,7 +190,7 @@ public abstract class ClientConfig {
                         "If set to false, the Java Opus implementation will be used, the denoiser won't be available and you won't be able to record audio."
                 );
         freecamSupport = builder
-                .booleanEntry("freecam_support", false,
+                .booleanEntry("freecam_support", true,
                         "This lets you hear players near your player even though you are further away with your freecam"
                 );
     }

--- a/common/src/main/java/de/maxhenkel/voicechat/config/ClientConfig.java
+++ b/common/src/main/java/de/maxhenkel/voicechat/config/ClientConfig.java
@@ -42,7 +42,6 @@ public abstract class ClientConfig {
     public ConfigEntry<Boolean> offlinePlayerVolumeAdjustment;
     public ConfigEntry<AudioType> audioType;
     public ConfigEntry<Boolean> useNatives;
-    public ConfigEntry<Boolean> freecamSupport;
 
     public ClientConfig(ConfigBuilder builder) {
 
@@ -188,10 +187,6 @@ public abstract class ClientConfig {
                 .booleanEntry("use_natives", !Platform.isMac() || VersionCheck.isMacOSNativeCompatible(),
                         "If the mod should load native libraries",
                         "If set to false, the Java Opus implementation will be used, the denoiser won't be available and you won't be able to record audio."
-                );
-        freecamSupport = builder
-                .booleanEntry("freecam_support", true,
-                        "This lets you hear players near your player even though you are further away with your freecam"
                 );
     }
 

--- a/common/src/main/java/de/maxhenkel/voicechat/integration/clothconfig/ClothConfigIntegration.java
+++ b/common/src/main/java/de/maxhenkel/voicechat/integration/clothconfig/ClothConfigIntegration.java
@@ -29,7 +29,6 @@ public class ClothConfigIntegration {
         general.addEntry(fromConfigEntry(entryBuilder, Component.translatable("cloth_config.voicechat.config.recording_destination"), VoicechatClient.CLIENT_CONFIG.recordingDestination));
         general.addEntry(fromConfigEntry(entryBuilder, Component.translatable("cloth_config.voicechat.config.run_local_server"), VoicechatClient.CLIENT_CONFIG.runLocalServer));
         general.addEntry(fromConfigEntry(entryBuilder, Component.translatable("cloth_config.voicechat.config.offline_player_volume_adjustment"), VoicechatClient.CLIENT_CONFIG.offlinePlayerVolumeAdjustment));
-        general.addEntry(fromConfigEntry(entryBuilder, Component.translatable("cloth_config.voicechat.config.freecam_support"), VoicechatClient.CLIENT_CONFIG.freecamSupport));
 
         ConfigCategory audio = builder.getOrCreateCategory(Component.translatable("cloth_config.voicechat.category.audio"));
         audio.addEntry(fromConfigEntry(entryBuilder, Component.translatable("cloth_config.voicechat.config.audio_packet_threshold"), VoicechatClient.CLIENT_CONFIG.audioPacketThreshold));

--- a/common/src/main/java/de/maxhenkel/voicechat/integration/freecam/FreecamUtil.java
+++ b/common/src/main/java/de/maxhenkel/voicechat/integration/freecam/FreecamUtil.java
@@ -1,6 +1,5 @@
 package de.maxhenkel.voicechat.integration.freecam;
 
-import de.maxhenkel.voicechat.VoicechatClient;
 import de.maxhenkel.voicechat.voice.client.PositionalAudioUtils;
 import net.minecraft.client.Minecraft;
 import net.minecraft.world.phys.Vec3;
@@ -13,9 +12,7 @@ public class FreecamUtil {
      * @return whether freecam is currently in use
      */
     public static boolean isFreecamEnabled() {
-        // FIXME once testing is complete, remove `freecamSupport` config option
-        return VoicechatClient.CLIENT_CONFIG.freecamSupport.get() &&
-                !(mc.player.isSpectator() || mc.player.equals(mc.getCameraEntity()));
+        return !(mc.player.isSpectator() || mc.player.equals(mc.getCameraEntity()));
     }
 
     /**

--- a/common/src/main/java/de/maxhenkel/voicechat/integration/freecam/FreecamUtil.java
+++ b/common/src/main/java/de/maxhenkel/voicechat/integration/freecam/FreecamUtil.java
@@ -1,0 +1,55 @@
+package de.maxhenkel.voicechat.integration.freecam;
+
+import de.maxhenkel.voicechat.VoicechatClient;
+import de.maxhenkel.voicechat.voice.client.PositionalAudioUtils;
+import net.minecraft.client.Minecraft;
+import net.minecraft.world.phys.Vec3;
+
+public class FreecamUtil {
+
+    private static final Minecraft mc = Minecraft.getInstance();
+
+    /**
+     * @return whether freecam is currently in use
+     */
+    public static boolean isFreecamEnabled() {
+        // FIXME once testing is complete, remove `freecamSupport` config option
+        return VoicechatClient.CLIENT_CONFIG.freecamSupport.get() &&
+                !(mc.player.isSpectator() || mc.player.equals(mc.getCameraEntity()));
+    }
+
+    /**
+     * Gets the proximity reference point. Unless freecam is active, this is the main camera's position.
+     *
+     * @return the position distances should be measured from
+     */
+    public static Vec3 getReferencePoint() {
+        return isFreecamEnabled() ?
+                mc.player.getEyePosition() : mc.gameRenderer.getMainCamera().getPosition();
+    }
+
+    /**
+     * Measures the distance to the provided position.
+     *
+     * Distance is relative to either the player or camera, depending on whether freecam is enabled.
+     *
+     * @param pos the position to be measured
+     * @return the distance to the position
+     */
+    public static double getDistanceTo(Vec3 pos) {
+        return getReferencePoint().distanceTo(pos);
+    }
+
+    /**
+     * Gets the volume for the provided distance.
+     *
+     * Distance is relative to either the player or camera, depending on whether freecam is enabled.
+     *
+     * @param maxDistance the maximum distance of the sound
+     * @param pos         the position of the audio
+     * @return the resulting audio volume
+     */
+    public static float getDistanceVolume(float maxDistance, Vec3 pos) {
+        return PositionalAudioUtils.getDistanceVolume(maxDistance, getReferencePoint(), pos);
+    }
+}

--- a/common/src/main/java/de/maxhenkel/voicechat/voice/client/AudioChannel.java
+++ b/common/src/main/java/de/maxhenkel/voicechat/voice/client/AudioChannel.java
@@ -3,9 +3,11 @@ package de.maxhenkel.voicechat.voice.client;
 import de.maxhenkel.voicechat.Voicechat;
 import de.maxhenkel.voicechat.VoicechatClient;
 import de.maxhenkel.voicechat.api.opus.OpusDecoder;
+import de.maxhenkel.voicechat.integration.freecam.FreecamUtil;
 import de.maxhenkel.voicechat.plugins.PluginManager;
 import de.maxhenkel.voicechat.plugins.impl.opus.OpusManager;
-import de.maxhenkel.voicechat.voice.client.speaker.*;
+import de.maxhenkel.voicechat.voice.client.speaker.Speaker;
+import de.maxhenkel.voicechat.voice.client.speaker.SpeakerManager;
 import de.maxhenkel.voicechat.voice.common.*;
 import net.minecraft.Util;
 import net.minecraft.client.Minecraft;
@@ -188,13 +190,6 @@ public class AudioChannel extends Thread {
             client.getTalkCache().updateTalking(uuid, false);
             appendRecording(() -> PositionalAudioUtils.convertToStereo(processedMonoData));
         } else if (packet instanceof PlayerSoundPacket soundPacket) {
-            if (VoicechatClient.CLIENT_CONFIG.freecamSupport.get() && getFreecamDistance() >= 8D) {
-                short[] processedMonoData = PluginManager.instance().onReceiveStaticClientSound(uuid, monoData);
-                speaker.play(processedMonoData, volume, soundPacket.getCategory());
-                client.getTalkCache().updateTalking(uuid, soundPacket.isWhispering());
-                appendRecording(() -> PositionalAudioUtils.convertToStereo(processedMonoData));
-                return;
-            }
             if (player == null) {
                 return;
             }
@@ -212,34 +207,38 @@ public class AudioChannel extends Thread {
 
             short[] processedMonoData = PluginManager.instance().onReceiveEntityClientSound(uuid, monoData, soundPacket.isWhispering(), soundPacket.getDistance());
 
-            if (pos.distanceTo(minecraft.gameRenderer.getMainCamera().getPosition()) > soundPacket.getDistance() + 1D) {
+            if (FreecamUtil.getDistanceTo(pos) > soundPacket.getDistance() + 1D) {
+                return;
+            }
+
+            float distanceVolume = FreecamUtil.getDistanceVolume(soundPacket.getDistance(), pos);
+
+            if (FreecamUtil.isFreecamEnabled()) {
+                // Static, but with volume adjusted for distance
+                volume *= distanceVolume;
+                speaker.play(processedMonoData, volume, soundPacket.getCategory());
+                if (distanceVolume > 0F) {
+                    client.getTalkCache().updateTalking(uuid, soundPacket.isWhispering());
+                }
+                float[] volumes = {volume, volume};
+                appendRecording(() -> PositionalAudioUtils.convertToStereo(processedMonoData, volumes));
                 return;
             }
 
             speaker.play(processedMonoData, volume, pos, soundPacket.getCategory(), soundPacket.getDistance());
-            if (PositionalAudioUtils.getDistanceVolume(soundPacket.getDistance(), pos) > 0F) {
+            if (distanceVolume > 0F) {
                 client.getTalkCache().updateTalking(uuid, soundPacket.isWhispering());
             }
             appendRecording(() -> PositionalAudioUtils.convertToStereoForRecording(soundPacket.getDistance(), pos, processedMonoData, deathVolume));
         } else if (packet instanceof LocationSoundPacket p) {
             short[] processedMonoData = PluginManager.instance().onReceiveLocationalClientSound(uuid, monoData, p.getLocation(), p.getDistance());
-            if (p.getLocation().distanceTo(minecraft.gameRenderer.getMainCamera().getPosition()) > p.getDistance() + 1D) {
+            if (FreecamUtil.getDistanceTo(p.getLocation()) > p.getDistance() + 1D) {
                 return;
             }
             speaker.play(processedMonoData, volume, p.getLocation(), p.getCategory(), p.getDistance());
             client.getTalkCache().updateTalking(uuid, false);
             appendRecording(() -> PositionalAudioUtils.convertToStereoForRecording(p.getDistance(), p.getLocation(), processedMonoData));
         }
-    }
-
-    private double getFreecamDistance() {
-        if (minecraft.player == null) {
-            return 0D;
-        }
-        if (minecraft.player.isSpectator()) {
-            return 0D;
-        }
-        return minecraft.player.getEyePosition().distanceTo(minecraft.gameRenderer.getMainCamera().getPosition());
     }
 
     private void appendRecording(Supplier<short[]> stereo) {

--- a/common/src/main/java/de/maxhenkel/voicechat/voice/client/PositionalAudioUtils.java
+++ b/common/src/main/java/de/maxhenkel/voicechat/voice/client/PositionalAudioUtils.java
@@ -152,7 +152,7 @@ public class PositionalAudioUtils {
      * @param volumes a float array of length 2 containing the left and right volume
      * @return the adjusted audio
      */
-    private static short[] convertToStereo(short[] audio, float[] volumes) {
+    public static short[] convertToStereo(short[] audio, float[] volumes) {
         return convertToStereo(audio, volumes[0], volumes[1]);
     }
 

--- a/common/src/main/resources/assets/voicechat/lang/de_de.json
+++ b/common/src/main/resources/assets/voicechat/lang/de_de.json
@@ -149,7 +149,6 @@
   "cloth_config.voicechat.config.recording_destination": "Aufnahmepfad",
   "cloth_config.voicechat.config.run_local_server": "In Einzelspieler/LAN Welten ausführen",
   "cloth_config.voicechat.config.offline_player_volume_adjustment": "Offline Spieler Lautstärkenanpassung",
-  "cloth_config.voicechat.config.freecam_support": "Freecam unterstützung",
   "cloth_config.voicechat.config.audio_packet_threshold": "Audio Paket Schwellenwert",
   "cloth_config.voicechat.config.deactivation_delay": "Verzögerung der Deaktivierung",
   "cloth_config.voicechat.config.output_buffer_size": "Größe des Ausgabepuffers",

--- a/common/src/main/resources/assets/voicechat/lang/en_us.json
+++ b/common/src/main/resources/assets/voicechat/lang/en_us.json
@@ -149,7 +149,6 @@
   "cloth_config.voicechat.config.recording_destination": "Recording destination",
   "cloth_config.voicechat.config.run_local_server": "Run in singleplayer/LAN worlds",
   "cloth_config.voicechat.config.offline_player_volume_adjustment": "Offline player volume adjustment",
-  "cloth_config.voicechat.config.freecam_support": "Freecam support",
   "cloth_config.voicechat.config.audio_packet_threshold": "Audio packet threshold",
   "cloth_config.voicechat.config.deactivation_delay": "Deactivation delay",
   "cloth_config.voicechat.config.output_buffer_size": "Output buffer size",

--- a/common/src/main/resources/assets/voicechat/lang/es_mx.json
+++ b/common/src/main/resources/assets/voicechat/lang/es_mx.json
@@ -146,7 +146,6 @@
   "cloth_config.voicechat.category.audio": "Audio",
   "cloth_config.voicechat.category.hud_icons": "Íconos del HUD",
   "cloth_config.voicechat.category.group_chat_icons": "Íconos del chat grupal",
-  "cloth_config.voicechat.config.freecam_support": "Soporte para Freecam",
   "cloth_config.voicechat.config.audio_packet_threshold": "Umbral de paquetes de audio",
   "cloth_config.voicechat.config.deactivation_delay": "Retraso de desactivación",
   "cloth_config.voicechat.config.output_buffer_size": "Tamaño de salida de búfer",

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -61,21 +61,26 @@ dependencies {
             "fabric-key-binding-api-v1"
     ]
 
+    // Fabric API. This is technically optional, but you probably want it anyway.
+    modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+
     apiModules.forEach {
         include(modImplementation(fabricApi.module(it, fabric_version)))
     }
 
     implementation project(path: ':common', configuration: 'namedElements')
 
-    // modImplementation "com.terraformersmc:modmenu:${modmenu_version}"
-    modCompileOnly "com.terraformersmc:modmenu:${modmenu_version}"
+     modImplementation "com.terraformersmc:modmenu:${modmenu_version}"
+//    modCompileOnly "com.terraformersmc:modmenu:${modmenu_version}"
 
     modApi("me.shedaniel.cloth:cloth-config-fabric:${cloth_config_version}") {
         exclude(group: 'net.fabricmc.fabric-api')
     }
 
     modImplementation "me.lucko:fabric-permissions-api:${fabric_permission_api_version}"
-    modCompileOnly "com.viaversion:viaversion-fabric:${viaversion_version}"
+    modImplementation "com.viaversion:viaversion-fabric:${viaversion_version}"
+
+    modImplementation files('freecam.jar')
 
     implementation 'com.google.code.findbugs:jsr305:3.0.2'
     implementation 'org.jetbrains:annotations:23.0.0'


### PR DESCRIPTION
Improved the check for being in freecam. Instead of checking the distance from the main camera to `mc.player`, we can check if the render entity is `mc.player` or not.

```java
public static boolean isFreecamEnabled() {
    return !(mc.player.isSpectator() || mc.player.equals(mc.getCameraEntity()));
}
```

---

Support distance-based volume while in freecam. The distance is calculated player-to-player. I.e. the camera's position is ignored.


```java
public static float getDistanceVolume(float maxDistance, Vec3 pos) {
    return PositionalAudioUtils.getDistanceVolume(maxDistance, getReferencePoint(), pos);
}

public static Vec3 getReferencePoint() {
    return isFreecamEnabled() ?
            mc.player.getEyePosition() : mc.gameRenderer.getMainCamera().getPosition();
}
```

---

Stereo effects are **currently not applied** while in freecam. During testing, I couldn't decide if it felt "right"" to hear players talking near `mc.player` in stereo when looking at them from an outside perspective.

It would be relatively simple to support stereo, by having pretty much all code use `FreecamUtil.getReferencePoint()` instead of the camera position, and also introducing a `FreecamUtil.getRotation()` to replace `Camera::getYRot`:

```java
public static float getYRotation() {
    return isFreecamEnabled() ?
            mc.player.getYRot() : mc.gameRenderer.getMainCamera().getYRot();
}
```

Using stereo would make freecam less of a special-case in `AudioChannel::writeToSpeaker`, but would mean more code would have to make use of `FreecamUtil` methods (e.g. `PositionalAudioUtils`, the `ALSpeaker` classes, etc)

---

`FreecamUtil.getDistanceTo(Vec3)` is used to check how/if packets should be sent/handled, rather than using the distance from the main camera:

```java
public static double getDistanceTo(Vec3 pos) {
    return getReferencePoint().distanceTo(pos);
}
```

---

I also included a commit which **removes** the `freecamSupport` config option, since IMO it is only useful for debugging edge-cases. Perhaps you'd rather merge that commit _later on_ after a period of beta-testing? If so, I've set the config option's default value to `true`.

---

Testing has been done using [hashalite's freecam](https://github.com/hashalite/Freecam) (I couldn't find any others supporting 1.19.4, I found two for 1.19.3 that wouldn't run). I've tested both with a dedicated server process and with the integrated (open-to-LAN) server.

Thank you for you work, help, discussion, etc on this issue. I look forward to your thoughts and review. :smile: 