### PR TITLE
Fixing microphone not working at random times on MacOS

### DIFF
--- a/common/src/main/java/de/maxhenkel/voicechat/voice/client/MicThread.java
+++ b/common/src/main/java/de/maxhenkel/voicechat/voice/client/MicThread.java
@@ -117,15 +117,18 @@ public class MicThread extends Thread {
         }
 
         if (mic.available() < SoundManager.FRAME_SIZE) {
-            if (mic.available() == 128)
-                amount128++;
-            else
-                amount128 = 0;
+            if (mic.available() == lastAmount)
+                amountnbr++;
+            else {
+                amountnbr = 0;
+                lastAmount = mic.available();
+            }
 
-            if (amount128 > 10) {
-                amount128 = 0;
+
+            if (amountnbr > 10) {
+                amountnbr = 0;
                 mic.stop();
-                Voicechat.LOGGER.info("Microphone stopped working. Restarting...");
+                Voicechat.LOGGER.info("Microphone stopped working. Restarting..." + lastAmount);
             }
             Utils.sleep(5);
             return null;
@@ -135,7 +138,8 @@ public class MicThread extends Thread {
         return denoiseIfEnabled(buff);
     }
 
-    private volatile int amount128 = 0;
+    private volatile int amountnbr = 0;
+    private volatile int lastAmount = 0;
     private volatile boolean activating;
     private volatile int deactivationDelay;
     private volatile short[] lastBuff;

--- a/common/src/main/java/de/maxhenkel/voicechat/voice/client/MicThread.java
+++ b/common/src/main/java/de/maxhenkel/voicechat/voice/client/MicThread.java
@@ -117,6 +117,16 @@ public class MicThread extends Thread {
         }
 
         if (mic.available() < SoundManager.FRAME_SIZE) {
+            if (mic.available() == 128)
+                amount128++;
+            else
+                amount128 = 0;
+
+            if (amount128 > 10) {
+                amount128 = 0;
+                mic.stop();
+                Voicechat.LOGGER.info("Microphone stopped working. Restarting...");
+            }
             Utils.sleep(5);
             return null;
         }
@@ -125,6 +135,7 @@ public class MicThread extends Thread {
         return denoiseIfEnabled(buff);
     }
 
+    private volatile int amount128 = 0;
     private volatile boolean activating;
     private volatile int deactivationDelay;
     private volatile short[] lastBuff;


### PR DESCRIPTION
Here's an issue I got with the mod running on macOS Ventura with PrismMC: 
Sometimes, at seemingly random intervals, the mic would just cut and not work. The only solution I found was to always disable the audio and put it back when the bug would occur, but I found that was a little stupid, so I decided to investigate.

To put it simply, I discovered that my bug occurred when mic.available() **always** returned 128. (Where normally it's a bunch of non-recurring numbers). (I tried using the ALMicrophone and the JavaxMicrophone implementations, but I had the same problem on both).

To solve the issue, I built this terrible code that would check if the mic.available() would continuously return 128, and if so, it would "restart" the microphone (similar of how I was able to "patch" the issue by disabling and re-enabling the audio).

I know my solution isn't very elegant, so don't be shy to completely change it. Maybe an OS check would be a good thing as I didn't test it on Windows.