### PR TITLE
Update Minecraft wiki link to new domain

### DIFF
--- a/.github/ISSUE_TEMPLATE/translation.md
+++ b/.github/ISSUE_TEMPLATE/translation.md
@@ -8,7 +8,7 @@ assignees: henkelmax
 ---
 
 **Locale code**
-Please provide the [Locale code](https://minecraft.gamepedia.com/Language#Available_languages) that Minecraft uses for this language.
+Please provide the [Locale code](https://minecraft.wiki/w/Language#Languages) that Minecraft uses for this language.
 
 **Translation**
 Please use a [https://gist.github.com/](https://gist.github.com/) link instead of pasting the translation here.


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates the old wiki link accordingly.

Would you like me to update more branches with this link?