### PR TITLE
Fix Event System Memory Leak

### DIFF
--- a/common/src/main/java/de/maxhenkel/voicechat/voice/server/PlayerStateManager.java
+++ b/common/src/main/java/de/maxhenkel/voicechat/voice/server/PlayerStateManager.java
@@ -22,9 +22,6 @@ public class PlayerStateManager {
     public PlayerStateManager(Server voicechatServer) {
         this.voicechatServer = voicechatServer;
         this.states = new ConcurrentHashMap<>();
-        CommonCompatibilityManager.INSTANCE.onServerVoiceChatConnected(this::onPlayerVoicechatConnect);
-        CommonCompatibilityManager.INSTANCE.onServerVoiceChatDisconnected(this::onPlayerVoicechatDisconnect);
-        CommonCompatibilityManager.INSTANCE.onPlayerCompatibilityCheckSucceeded(this::onPlayerCompatibilityCheckSucceeded);
 
         CommonCompatibilityManager.INSTANCE.getNetManager().updateStateChannel.setServerListener((server, player, handler, packet) -> {
             PlayerState state = states.get(player.getUUID());
@@ -48,7 +45,7 @@ public class PlayerStateManager {
         PluginManager.instance().onPlayerStateChanged(state);
     }
 
-    private void onPlayerCompatibilityCheckSucceeded(ServerPlayer player) {
+    public void onPlayerCompatibilityCheckSucceeded(ServerPlayer player) {
         PlayerStatesPacket packet = new PlayerStatesPacket(states);
         NetManager.sendToClient(player, packet);
         Voicechat.LOGGER.debug("Sending initial states to {}", player.getDisplayName().getString());
@@ -67,7 +64,7 @@ public class PlayerStateManager {
         Voicechat.LOGGER.debug("Removing state of {}", player.getDisplayName().getString());
     }
 
-    private void onPlayerVoicechatDisconnect(UUID uuid) {
+    public void onPlayerVoicechatDisconnect(UUID uuid) {
         PlayerState state = states.get(uuid);
         if (state == null) {
             return;
@@ -79,7 +76,7 @@ public class PlayerStateManager {
         Voicechat.LOGGER.debug("Set state of {} to disconnected: {}", uuid, state);
     }
 
-    private void onPlayerVoicechatConnect(ServerPlayer player) {
+    public void onPlayerVoicechatConnect(ServerPlayer player) {
         PlayerState state = states.get(player.getUUID());
 
         if (state == null) {

--- a/common/src/main/java/de/maxhenkel/voicechat/voice/server/Server.java
+++ b/common/src/main/java/de/maxhenkel/voicechat/voice/server/Server.java
@@ -64,8 +64,6 @@ public class Server extends Thread {
         playerStateManager = new PlayerStateManager(this);
         groupManager = new ServerGroupManager(this);
         categoryManager = new ServerCategoryManager(this);
-        CommonCompatibilityManager.INSTANCE.onPlayerLoggedIn(this::onPlayerLoggedIn);
-        CommonCompatibilityManager.INSTANCE.onPlayerLoggedOut(this::onPlayerLoggedOut);
         setDaemon(true);
         setName("VoiceChatServerThread");
         setUncaughtExceptionHandler(new VoicechatUncaughtExceptionHandler());
@@ -73,13 +71,28 @@ public class Server extends Thread {
         processThread.start();
     }
 
-    private void onPlayerLoggedIn(ServerPlayer player) {
+    public void onPlayerLoggedIn(ServerPlayer player) {
         playerStateManager.onPlayerLoggedIn(player);
     }
 
-    private void onPlayerLoggedOut(ServerPlayer player) {
+    public void onPlayerLoggedOut(ServerPlayer player) {
+        this.disconnectClient(player.getUUID());
         playerStateManager.onPlayerLoggedOut(player);
         groupManager.onPlayerLoggedOut(player);
+    }
+
+    public void onPlayerVoicechatConnect(ServerPlayer player) {
+        playerStateManager.onPlayerVoicechatConnect(player);
+    }
+
+    public void onPlayerVoicechatDisconnect(UUID uuid) {
+        playerStateManager.onPlayerVoicechatDisconnect(uuid);
+    }
+
+    public void onPlayerCompatibilityCheckSucceeded(ServerPlayer player) {
+        playerStateManager.onPlayerCompatibilityCheckSucceeded(player);
+        groupManager.onPlayerCompatibilityCheckSucceeded(player);
+        categoryManager.onPlayerCompatibilityCheckSucceeded(player);
     }
 
     @Override

--- a/common/src/main/java/de/maxhenkel/voicechat/voice/server/ServerCategoryManager.java
+++ b/common/src/main/java/de/maxhenkel/voicechat/voice/server/ServerCategoryManager.java
@@ -18,10 +18,9 @@ public class ServerCategoryManager extends CategoryManager {
 
     public ServerCategoryManager(Server server) {
         this.server = server;
-        CommonCompatibilityManager.INSTANCE.onPlayerCompatibilityCheckSucceeded(this::onPlayerCompatibilityCheckSucceeded);
     }
 
-    private void onPlayerCompatibilityCheckSucceeded(ServerPlayer player) {
+    public void onPlayerCompatibilityCheckSucceeded(ServerPlayer player) {
         Voicechat.LOGGER.debug("Synchronizing {} volume categories with {}", categories.size(), player.getDisplayName().getString());
         for (VolumeCategoryImpl category : getCategories()) {
             broadcastAddCategory(server.getServer(), category);

--- a/common/src/main/java/de/maxhenkel/voicechat/voice/server/ServerGroupManager.java
+++ b/common/src/main/java/de/maxhenkel/voicechat/voice/server/ServerGroupManager.java
@@ -26,7 +26,7 @@ public class ServerGroupManager {
     public ServerGroupManager(Server server) {
         this.server = server;
         groups = new ConcurrentHashMap<>();
-        CommonCompatibilityManager.INSTANCE.onPlayerCompatibilityCheckSucceeded(this::onPlayerCompatibilityCheckSucceeded);
+
         CommonCompatibilityManager.INSTANCE.getNetManager().joinGroupChannel.setServerListener((srv, player, handler, packet) -> {
             if (!Voicechat.SERVER_CONFIG.groupsEnabled.get()) {
                 return;
@@ -56,7 +56,7 @@ public class ServerGroupManager {
         });
     }
 
-    private void onPlayerCompatibilityCheckSucceeded(ServerPlayer player) {
+    public void onPlayerCompatibilityCheckSucceeded(ServerPlayer player) {
         Voicechat.LOGGER.debug("Synchronizing {} groups with {}", groups.size(), player.getDisplayName().getString());
         for (Group category : groups.values()) {
             broadcastAddGroup(category);

--- a/common/src/main/java/de/maxhenkel/voicechat/voice/server/ServerVoiceEvents.java
+++ b/common/src/main/java/de/maxhenkel/voicechat/voice/server/ServerVoiceEvents.java
@@ -31,6 +31,10 @@ public class ServerVoiceEvents {
         CommonCompatibilityManager.INSTANCE.onPlayerLoggedOut(this::playerLoggedOut);
         CommonCompatibilityManager.INSTANCE.onServerStopping(this::serverStopping);
 
+        CommonCompatibilityManager.INSTANCE.onServerVoiceChatConnected(this::serverVoiceChatConnected);
+        CommonCompatibilityManager.INSTANCE.onServerVoiceChatDisconnected(this::serverVoiceChatDisconnected);
+        CommonCompatibilityManager.INSTANCE.onPlayerCompatibilityCheckSucceeded(this::playerCompatibilityCheckSucceeded);
+
         CommonCompatibilityManager.INSTANCE.getNetManager().requestSecretChannel.setServerListener((server, player, handler, packet) -> {
             Voicechat.LOGGER.info("Received secret request of {} ({})", player.getDisplayName().getString(), packet.getCompatibilityVersion());
             clientCompatibilities.put(player.getUUID(), packet.getCompatibilityVersion());
@@ -104,6 +108,10 @@ public class ServerVoiceEvents {
     }
 
     public void playerLoggedIn(ServerPlayer serverPlayer) {
+        if (server != null) {
+            server.onPlayerLoggedIn(serverPlayer);
+        }
+
         if (!Voicechat.SERVER_CONFIG.forceVoiceChat.get()) {
             return;
         }
@@ -140,8 +148,32 @@ public class ServerVoiceEvents {
             return;
         }
 
-        server.disconnectClient(player.getUUID());
+        server.onPlayerLoggedOut(player);
         Voicechat.LOGGER.info("Disconnecting client {}", player.getDisplayName().getString());
+    }
+
+    public void serverVoiceChatConnected(ServerPlayer serverPlayer) {
+        if (server == null) {
+            return;
+        }
+
+        server.onPlayerVoicechatConnect(serverPlayer);
+    }
+
+    public void serverVoiceChatDisconnected(UUID uuid) {
+        if (server == null) {
+            return;
+        }
+
+        server.onPlayerVoicechatDisconnect(uuid);
+    }
+
+    public void playerCompatibilityCheckSucceeded(ServerPlayer player) {
+        if (server == null) {
+            return;
+        }
+
+        server.onPlayerCompatibilityCheckSucceeded(player);
     }
 
     @Nullable


### PR DESCRIPTION
The event system keeps many objects in memory as the listeners are never deregistered. The biggest consequence has to do with `PlayerStateManager`'s constructor. It registers a lambda `onServerVoiceChatConnected` which is never deregistered which means the garbage collector can't clean up `PlayerStateManager` which can't clean up `Server` which can't clean up `MinecraftServer`. This makes it impossible to load into more than a handful of worlds before requiring a restart.

This PR fixes the memory leak by registering the event only once globally, which won't prevent the garbage collector from discarding the world instances when they are no longer used. I have been unable to test the fix as my workspace is broken so please review carefully. It would be nice if the fix was backported too, I need it for 1.20.1.