### PR TITLE
[Proxy] Add support for unresolved InetSocketAddress

### DIFF
--- a/common-proxy/src/main/java/de/maxhenkel/voicechat/VoiceProxy.java
+++ b/common-proxy/src/main/java/de/maxhenkel/voicechat/VoiceProxy.java
@@ -68,7 +68,7 @@ public abstract class VoiceProxy {
         if (port == null) {
             port = backendSocket.getPort();
         }
-        return new InetSocketAddress(backendSocket.getAddress(), port);
+        return new InetSocketAddress(backendSocket.getHostString(), port);
     }
 
     /**

--- a/velocity/src/main/java/de/maxhenkel/voicechat/SimpleVoiceChatVelocity.java
+++ b/velocity/src/main/java/de/maxhenkel/voicechat/SimpleVoiceChatVelocity.java
@@ -54,7 +54,13 @@ public class SimpleVoiceChatVelocity extends VoiceProxy {
         }
 
         Optional<ServerConnection> server = player.get().getCurrentServer();
-        return server.map(serverConnection -> serverConnection.getServerInfo().getAddress()).orElse(null);
+        if (server.isEmpty()) return null;
+
+        InetSocketAddress serverSocket = server.get().getServerInfo().getAddress();
+        if (serverSocket.isUnresolved()) {
+            serverSocket = new InetSocketAddress(serverSocket.getHostString(), serverSocket.getPort());
+        }
+        return serverSocket;
     }
 
     @Override


### PR DESCRIPTION
Resolves an issue where an unresolved InetSocketAddress would result in failure to connect to the backend server. Fixed it both in the velocity plugin and generally in common-proxy.