### PR TITLE
[Proxy] Shrink Buffer due to overallocation in 1.20.6

### DIFF
--- a/common-proxy/src/main/java/de/maxhenkel/voicechat/sniffer/SniffedSecretPacket.java
+++ b/common-proxy/src/main/java/de/maxhenkel/voicechat/sniffer/SniffedSecretPacket.java
@@ -4,6 +4,7 @@ import de.maxhenkel.voicechat.VoiceProxy;
 import de.maxhenkel.voicechat.util.ByteBufferWrapper;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.UUID;
 
 public class SniffedSecretPacket {
@@ -54,7 +55,7 @@ public class SniffedSecretPacket {
         buf.writeBoolean(groupsEnabled);
         buf.writeUtf(voiceHost, 32767);
         buf.writeBoolean(allowRecording);
-        return buffer;
+        return ByteBuffer.wrap(Arrays.copyOfRange(buffer.array(), 0, buffer.position()));
     }
 
     public UUID getSecret() {


### PR DESCRIPTION
The size calculation is magic to me with all these numbers so I was not able to fix this by correcting the size. Also further complicating things is that this size calculation worked for older versions.

So the easiest workaround I found was to simply shrink the buffer to the actual size to counter the over-allocation issue.

Feel free to rework as needed if you know how to fix the size calculation tho!