### PR TITLE
Improved the ping response time message

### DIFF
--- a/bukkit/src/main/java/de/maxhenkel/voicechat/command/VoiceChatCommands.java
+++ b/bukkit/src/main/java/de/maxhenkel/voicechat/command/VoiceChatCommands.java
@@ -132,7 +132,7 @@ public class VoiceChatCommands implements CommandExecutor, TabCompleter {
                     if (attempts <= 1) {
                         NetManager.sendMessage(commandSender, Component.translatable("message.voicechat.ping_received", Component.text(pingMilliseconds)));
                     } else {
-                        NetManager.sendMessage(commandSender, Component.translatable("message.voicechat.ping_received_attempt", Component.text(attempts), Component.text(pingMilliseconds)));
+                        NetManager.sendMessage(commandSender, Component.translatable("message.voicechat.ping_received_attempt", Component.text(pingMilliseconds), Component.text(attempts)));
                     }
                 }
 

--- a/common/src/main/java/de/maxhenkel/voicechat/command/VoicechatCommands.java
+++ b/common/src/main/java/de/maxhenkel/voicechat/command/VoicechatCommands.java
@@ -73,7 +73,7 @@ public class VoicechatCommands {
                         if (attempts <= 1) {
                             commandSource.getSource().sendSuccess(() -> Component.translatable("message.voicechat.ping_received", pingMilliseconds), false);
                         } else {
-                            commandSource.getSource().sendSuccess(() -> Component.translatable("message.voicechat.ping_received_attempt", attempts, pingMilliseconds), false);
+                            commandSource.getSource().sendSuccess(() -> Component.translatable("message.voicechat.ping_received_attempt", pingMilliseconds, attempts), false);
                         }
                     }
 

--- a/common/src/main/resources/assets/voicechat/lang/de_de.json
+++ b/common/src/main/resources/assets/voicechat/lang/de_de.json
@@ -46,7 +46,6 @@
   "message.voicechat.sending_ping": "Sende Ping...",
   "message.voicechat.ping_sent_waiting": "Ping gesendet. Auf Antwort warten....",
   "message.voicechat.ping_received": "Ping in %sms erhalten",
-  "message.voicechat.ping_received_attempt": "Ping nach %s versuchen in %sms erhalten",
   "message.voicechat.ping_retry": "Keine Antwort. Versuche erneut...",
   "message.voicechat.ping_timed_out": "Anfrage nach %s Versuchen ausgelaufen",
   "message.voicechat.icons_hidden": "Sprachchat Icons ausgeblendet",

--- a/common/src/main/resources/assets/voicechat/lang/en_us.json
+++ b/common/src/main/resources/assets/voicechat/lang/en_us.json
@@ -46,7 +46,7 @@
   "message.voicechat.sending_ping": "Sending ping...",
   "message.voicechat.ping_sent_waiting": "Ping sent. Waiting for response...",
   "message.voicechat.ping_received": "Got a response in %s ms",
-  "message.voicechat.ping_received_attempt": "Got a response after %s attempts in %s ms",
+  "message.voicechat.ping_received_attempt": "Got a response in %s ms after %s attempts",
   "message.voicechat.ping_retry": "No response. Retrying...",
   "message.voicechat.ping_timed_out": "Request timed out after %s attempts",
   "message.voicechat.icons_hidden": "Voice chat icons hidden",

--- a/common/src/main/resources/assets/voicechat/lang/es_es.json
+++ b/common/src/main/resources/assets/voicechat/lang/es_es.json
@@ -46,7 +46,6 @@
   "message.voicechat.sending_ping": "Enviando ping…",
   "message.voicechat.ping_sent_waiting": "Ping enviado. Esperando respuesta…",
   "message.voicechat.ping_received": "Recibí una respuesta en %sms",
-  "message.voicechat.ping_received_attempt": "Recibí una respuesta después de %s intentos en %sms",
   "message.voicechat.ping_retry": "No hay respuesta. Reintentando…",
   "message.voicechat.ping_timed_out": "Solicitud agotada tras %s intentos",
   "message.voicechat.icons_hidden": "Iconos de chat de voz ocultos",

--- a/common/src/main/resources/assets/voicechat/lang/es_mx.json
+++ b/common/src/main/resources/assets/voicechat/lang/es_mx.json
@@ -46,7 +46,6 @@
   "message.voicechat.sending_ping": "Enviando ping...",
   "message.voicechat.ping_sent_waiting": "Ping enviado. Esperando respuesta...",
   "message.voicechat.ping_received": "Se obtuvo respuesta de %sms",
-  "message.voicechat.ping_received_attempt": "Se obtuvo respuesta después de %s intentos de %sms",
   "message.voicechat.ping_retry": "Sin respuesta. Reintentando...",
   "message.voicechat.ping_timed_out": "Tiempo de espera agotado después de %s intentos",
   "message.voicechat.icons_hidden": "Íconos del chat de voz ocultos",

--- a/common/src/main/resources/assets/voicechat/lang/fr_fr.json
+++ b/common/src/main/resources/assets/voicechat/lang/fr_fr.json
@@ -44,7 +44,6 @@
   "message.voicechat.sending_ping": "Envoi du ping en cours...",
   "message.voicechat.ping_sent_waiting": "Ping envoyé. Attente de la réponse...",
   "message.voicechat.ping_received": "Réponse reçue en %sms",
-  "message.voicechat.ping_received_attempt": "Réponse reçue après %s tentatives en %sms",
   "message.voicechat.ping_retry": "Aucune réponse. Nouvelle tentative...",
   "message.voicechat.ping_timed_out": "Délai d'attente dépassé après %s tentatives",
   "message.voicechat.icons_hidden": "Icônes du chat vocal masquées",

--- a/common/src/main/resources/assets/voicechat/lang/ja_jp.json
+++ b/common/src/main/resources/assets/voicechat/lang/ja_jp.json
@@ -46,7 +46,6 @@
   "message.voicechat.sending_ping": "Pingの送信中...",
   "message.voicechat.ping_sent_waiting": "Pingの送信完了。応答の待機中...",
   "message.voicechat.ping_received": "%smsで応答を受信しました。",
-  "message.voicechat.ping_received_attempt": "%smsで%s回試行した後、応答がありました",
   "message.voicechat.ping_retry": "応答なし。再試行中...",
   "message.voicechat.ping_timed_out": "%s回の試行後にリクエストがタイムアウトしました",
   "message.voicechat.icons_hidden": "ボイスチャットアイコンを隠しました",

--- a/common/src/main/resources/assets/voicechat/lang/ko_kr.json
+++ b/common/src/main/resources/assets/voicechat/lang/ko_kr.json
@@ -46,7 +46,6 @@
   "message.voicechat.sending_ping": "핑 전송 중...",
   "message.voicechat.ping_sent_waiting": "핑 전송함. 응답을 기다리는 중...",
   "message.voicechat.ping_received": "%sms 안에 응답을 수신함",
-  "message.voicechat.ping_received_attempt": "%s번 시도하여 %sms 안에 응답을 수신함",
   "message.voicechat.ping_retry": "응답이 없음. 다시 시도 중...",
   "message.voicechat.ping_timed_out": "%s번 시도 이후 요청 시간 초과",
   "message.voicechat.icons_hidden": "음성 채팅 아이콘 숨김",

--- a/common/src/main/resources/assets/voicechat/lang/no_no.json
+++ b/common/src/main/resources/assets/voicechat/lang/no_no.json
@@ -43,7 +43,6 @@
   "message.voicechat.sending_ping": "Sender ping...",
   "message.voicechat.ping_sent_waiting": "Ping sendt. Venter på svar...",
   "message.voicechat.ping_received": "Got a response in %sms",
-  "message.voicechat.ping_received_attempt": "Fikk svar etter %s forsøk innen %sms",
   "message.voicechat.ping_retry": "Ingen svar. Forsøker igjen...",
   "message.voicechat.ping_timed_out": "Forespørselen ble tidsavbrutt etter %s forsøk",
   "message.voicechat.icons_hidden": "Stemmepratikoner skjult",

--- a/common/src/main/resources/assets/voicechat/lang/pl_pl.json
+++ b/common/src/main/resources/assets/voicechat/lang/pl_pl.json
@@ -43,7 +43,6 @@
   "message.voicechat.sending_ping": "Wysyłanie pingu...",
   "message.voicechat.ping_sent_waiting": "Ping wysłany. Czekanie na odpowiedź...",
   "message.voicechat.ping_received": "Dostano odpowiedź w %sms",
-  "message.voicechat.ping_received_attempt": "Dostano odpowiedź po %s próbach w %sms",
   "message.voicechat.ping_retry": "Nie ma odpowiedzi. Powtarzanie...",
   "message.voicechat.ping_timed_out": "Prośba wygasła po %s próbach",
   "message.voicechat.icons_hidden": "Ikony czatu głosowego ukryte",

--- a/common/src/main/resources/assets/voicechat/lang/pt_br.json
+++ b/common/src/main/resources/assets/voicechat/lang/pt_br.json
@@ -44,7 +44,6 @@
   "message.voicechat.sending_ping": "Enviando ping...",
   "message.voicechat.ping_sent_waiting": "Ping enviado. Aguardando resposta...",
   "message.voicechat.ping_received": "Resposta recebida em %sms",
-  "message.voicechat.ping_received_attempt": "Resposta recebida após %s falhas em %sms",
   "message.voicechat.ping_retry": "Sem resposta. Enviando novamente...",
   "message.voicechat.ping_timed_out": "Solicitação expirada após %s falhas",
   "message.voicechat.icons_hidden": "Ícones do Voice Chat ocultos",

--- a/common/src/main/resources/assets/voicechat/lang/pt_pt.json
+++ b/common/src/main/resources/assets/voicechat/lang/pt_pt.json
@@ -46,7 +46,6 @@
   "message.voicechat.sending_ping": "Enviando ping...",
   "message.voicechat.ping_sent_waiting": "Ping enviado. À espera de resposta...",
   "message.voicechat.ping_received": "Resposta obtida em %sms",
-  "message.voicechat.ping_received_attempt": "Resposta obtida depois de %s tentativas em %sms",
   "message.voicechat.ping_retry": "Nenhuma resposta. Tentando novamente...",
   "message.voicechat.ping_timed_out": "O pedido expirou após %s tentativas",
   "message.voicechat.icons_hidden": "Ícones de chat de voz ocultados",

--- a/common/src/main/resources/assets/voicechat/lang/ru_ru.json
+++ b/common/src/main/resources/assets/voicechat/lang/ru_ru.json
@@ -46,7 +46,6 @@
   "message.voicechat.sending_ping": "Отправка запроса на соединение...",
   "message.voicechat.ping_sent_waiting": "Запрос на соединение отправлен. Ожидание ответа...",
   "message.voicechat.ping_received": "Получен ответ за %s мс",
-  "message.voicechat.ping_received_attempt": "Получен ответ после %s попыток за %s мс",
   "message.voicechat.ping_retry": "Нет ответа. Повторная попытка...",
   "message.voicechat.ping_timed_out": "Время запроса истекло после %s попыток",
   "message.voicechat.icons_hidden": "Иконки голосового чата скрыты",

--- a/common/src/main/resources/assets/voicechat/lang/sv_se.json
+++ b/common/src/main/resources/assets/voicechat/lang/sv_se.json
@@ -46,7 +46,6 @@
   "message.voicechat.sending_ping": "Skickar ping...",
   "message.voicechat.ping_sent_waiting": "Ping skickad. Väntar på svar...",
   "message.voicechat.ping_received": "Fick svar på %sms",
-  "message.voicechat.ping_received_attempt": "Fick svar efter %s försök på %sms",
   "message.voicechat.ping_retry": "Inget svar. Försöker igen...",
   "message.voicechat.ping_timed_out": "Tidsgräns för begäran nådd efter %s försök",
   "message.voicechat.icons_hidden": "Röstchattsikoner gömda",

--- a/common/src/main/resources/assets/voicechat/lang/tr_tr.json
+++ b/common/src/main/resources/assets/voicechat/lang/tr_tr.json
@@ -46,7 +46,6 @@
   "message.voicechat.sending_ping": "Ping gönderiliyor...",
   "message.voicechat.ping_sent_waiting": "Ping gönderildi. Yanıt...",
   "message.voicechat.ping_received": "%s milisaniyede yanıt alındı",
-  "message.voicechat.ping_received_attempt": "%s denemeden sonra %s milisaniyede yanıt alındı",
   "message.voicechat.ping_retry": "Yanıt alınamadı. Yeniden deneniyor...",
   "message.voicechat.ping_timed_out": "İstek %s denemeden sonra zaman aşımına uğradı",
   "message.voicechat.icons_hidden": "Sesli sohbet simgeleri gizli",

--- a/common/src/main/resources/assets/voicechat/lang/tt_ru.json
+++ b/common/src/main/resources/assets/voicechat/lang/tt_ru.json
@@ -44,7 +44,6 @@
   "message.voicechat.sending_ping": "Пинг җибәрү...",
   "message.voicechat.ping_sent_waiting": "Пинг җибәрелде. Җавап көтү...",
   "message.voicechat.ping_received": "%s мс эчендә җавап алды",
-  "message.voicechat.ping_received_attempt": "Җавап %s тапкырдан соң %s мс эчендә алынды",
   "message.voicechat.ping_retry": "Җавап юк. Кабатлау...",
   "message.voicechat.ping_timed_out": "Җавап вакыты %s тапкырдан соң бетте",
   "message.voicechat.icons_hidden": "Тавышлы чат тамгачыклары яшерен",

--- a/common/src/main/resources/assets/voicechat/lang/uk_ua.json
+++ b/common/src/main/resources/assets/voicechat/lang/uk_ua.json
@@ -46,7 +46,6 @@
   "message.voicechat.sending_ping": "Надсилаємо пінг...",
   "message.voicechat.ping_sent_waiting": "Пінг надіслано. Очікування відповіді...",
   "message.voicechat.ping_received": "Отримав відповідь у %sмс",
-  "message.voicechat.ping_received_attempt": "Отримано відповідь після %s спроб у %sмс",
   "message.voicechat.ping_retry": "Немає відповіді. Повторна спроба...",
   "message.voicechat.ping_timed_out": "Час очікування запиту минув після %s спроб",
   "message.voicechat.icons_hidden": "Значки голосового чату приховані",

--- a/common/src/main/resources/assets/voicechat/lang/vi_vn.json
+++ b/common/src/main/resources/assets/voicechat/lang/vi_vn.json
@@ -46,7 +46,6 @@
   "message.voicechat.sending_ping": "Đang gửi ping...",
   "message.voicechat.ping_sent_waiting": "Đã gửi ping. Đang chờ phản hồi...",
   "message.voicechat.ping_received": "Đã phản hồi trong %sms",
-  "message.voicechat.ping_received_attempt": "Đã phản hồi sau %s lần thử và trong %sms",
   "message.voicechat.ping_retry": "Không có phản hồi. Đang thử lại",
   "message.voicechat.ping_timed_out": "Quá thời gian phản hồi sau %s lần thử",
   "message.voicechat.icons_hidden": "Đã ẩn các biểu tượng voice chat",

--- a/common/src/main/resources/assets/voicechat/lang/zh_cn.json
+++ b/common/src/main/resources/assets/voicechat/lang/zh_cn.json
@@ -46,7 +46,6 @@
   "message.voicechat.sending_ping": "发送 Ping...",
   "message.voicechat.ping_sent_waiting": "已发送 Ping,等待回应...",
   "message.voicechat.ping_received": "%sms 后得到回应",
-  "message.voicechat.ping_received_attempt": "在 %s 次尝试后 %sms 得到回应",
   "message.voicechat.ping_retry": "无回应，正在重试...",
   "message.voicechat.ping_timed_out": "在 %s 次尝试后超时",
   "message.voicechat.icons_hidden": "语音通话图标：隐藏",

--- a/common/src/main/resources/assets/voicechat/lang/zh_tw.json
+++ b/common/src/main/resources/assets/voicechat/lang/zh_tw.json
@@ -46,7 +46,6 @@
   "message.voicechat.sending_ping": "正在傳送 Ping...",
   "message.voicechat.ping_sent_waiting": "已傳送 Ping。等待回覆中...",
   "message.voicechat.ping_received": "在 %s 毫秒得到回覆",
-  "message.voicechat.ping_received_attempt": "在 %s 次嘗試後在 %s 毫秒得到回覆",
   "message.voicechat.ping_retry": "沒有回覆。重試中...",
   "message.voicechat.ping_timed_out": "%s 次嘗試後要求等候逾時",
   "message.voicechat.icons_hidden": "語音聊天圖示隱藏",


### PR DESCRIPTION
This is a small follow-up to the absolutely massive PR #736 that was recently accepted and merged. It was agreed upon to separate out this small but, unfortunately, breaking change into its own pull request.

The current message that is still in use looks like this: "Got a response after 3 attempts in 150 ms".

Depending on the language and how it is translated, this may suggest that it was the 3 attempts that took 150 ms, and only the fourth attempt was successful without mentioning how long the packet took. If I were to visualize it, it would look something like this: "Got a response (after 3 attempts in 150 ms)". But the intended meaning has always been more like this: "Got a response (after 3 attempts) in 150 ms", meaning that the response took 150 ms, with 3 unsuccessful attempts beforehand.

Therefore, I propose to swap the order of the time in milliseconds it took for the ping to travel back and forth with the number of previous attempts that failed. The new message would look like this: "Got a response in 150 ms after 3 attempts" and would better convey the intended meaning. The only downside is that most of the existing translations now need to be redone.