### PR TITLE
Polish translation update

### DIFF
--- a/common/src/main/resources/assets/voicechat/lang/pl_pl.json
+++ b/common/src/main/resources/assets/voicechat/lang/pl_pl.json
@@ -46,6 +46,7 @@
   "message.voicechat.sending_ping": "Wysyłanie polecenia ping...",
   "message.voicechat.ping_sent_waiting": "Polecenie ping wysłane. Oczekiwanie na odpowiedź...",
   "message.voicechat.ping_received": "Otrzymano odpowiedź w ciągu %s ms",
+  "message.voicechat.ping_received_attempt": "Otrzymano odpowiedź w ciągu %s ms po %s próbach",
   "message.voicechat.ping_retry": "Brak odpowiedzi. Ponawianie próby...",
   "message.voicechat.ping_timed_out": "Upłynął limit czasu żądania po %s próbach",
   "message.voicechat.icons_hidden": "Ikony czatu głosowego ukryte",


### PR DESCRIPTION
This pull request can be viewed as a continuation of the recently merged PR #744. Its purpose is to include the latest changes to the `message.voicechat.ping_received_attempt` translation key from commit eb2c8b4f823a7ed163b113d1028025b283e95867 so that the Polish translation is 100% complete. Finally!

Although the translated text for the translation key mentioned above was already part of the linked pull request (hence the hard dependency mentioned there), it seems to have been lost somewhere during the merge process. And that's exactly what this PR is for — to restore the text that got lost somewhere along the way.