### PR TITLE
Update username cache to be an appendable file with conversion -

### DIFF
--- a/common-client/src/main/java/de/maxhenkel/voicechat/VoicechatClient.java
+++ b/common-client/src/main/java/de/maxhenkel/voicechat/VoicechatClient.java
@@ -48,7 +48,8 @@ public abstract class VoicechatClient {
         fixVolumeConfig();
         CLIENT_CONFIG = ConfigBuilder.builder(ClientConfig::new).path(Voicechat.getVoicechatConfigFolder().resolve("voicechat-client.properties")).build();
         VOLUME_CONFIG = new VolumeConfig(Voicechat.getVoicechatConfigFolder().resolve("voicechat-volumes.properties"));
-        USERNAME_CACHE = new UsernameCache(Voicechat.getVoicechatConfigFolder().resolve("username-cache.json").toFile());
+        USERNAME_CACHE = new UsernameCache(Voicechat.getVoicechatConfigFolder().resolve("username-cache.json").toFile(),
+                Voicechat.getVoicechatConfigFolder().resolve("username-cache.txt").toFile());
     }
 
     public void initializeClient() {

--- a/common-client/src/main/java/de/maxhenkel/voicechat/profile/UsernameCache.java
+++ b/common-client/src/main/java/de/maxhenkel/voicechat/profile/UsernameCache.java
@@ -3,11 +3,19 @@ package de.maxhenkel.voicechat.profile;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
+import com.sun.jna.platform.win32.OaIdl;
 import de.maxhenkel.voicechat.Voicechat;
+import it.unimi.dsi.fastutil.ints.IntSets;
+import net.minecraft.advancements.critereon.LightningStrikeTrigger;
 
 import javax.annotation.Nullable;
+import javax.print.DocFlavor;
 import java.io.*;
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Base64;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -24,24 +32,68 @@ public class UsernameCache {
     });
 
     private final File file;
+    private final File appendingFormattedFile;
     private final Gson gson;
     private Map<UUID, String> names;
 
-    public UsernameCache(File file) {
+    public UsernameCache(File file, File appendingFormattedFile) {
         this.file = file;
+        this.appendingFormattedFile = appendingFormattedFile;
         this.gson = new GsonBuilder().create();
         this.names = new ConcurrentHashMap<>();
         load();
     }
 
+    public void convert() {
+        long t1 = System.nanoTime();
+        try(FileOutputStream fileOutputStream = new FileOutputStream(this.appendingFormattedFile, true)) {
+            for (Map.Entry<UUID, String> uuidStringEntry : this.names.entrySet()) {
+                String line = uuidStringEntry.getKey().toString() + "#" + uuidStringEntry.getValue()+"\n";
+                fileOutputStream.write(line.getBytes(StandardCharsets.UTF_8));
+            }
+        } catch (IOException e) {
+            Voicechat.LOGGER.error("Failed to convert username cache", e);
+            return; // failure should not delete main cache.
+        }
+        if (this.file.delete()) {
+            long t2 = System.nanoTime();
+            Voicechat.LOGGER.debug("Username cache has been converted. " + (t2-t1)/(1_000_000.0) + " ms");
+        }
+    }
+
+    public void loadAppending() {
+        try {
+            List<String> cacheLines = Files.readAllLines(this.appendingFormattedFile.toPath());
+            for (String cacheLine : cacheLines) {
+                String[] encodedData = cacheLine.split("#");
+                try {
+                    UUID id = UUID.fromString(encodedData[0]);
+                    String userName = encodedData[1];
+                    this.names.put(id, userName);
+                } catch (Exception e) {
+                    Voicechat.LOGGER.error("Found corrupt entry in file: " + cacheLine);
+                    e.printStackTrace();
+                }
+            }
+            Voicechat.LOGGER.debug("Loaded username cache with " + this.names.size() + " entries");
+        } catch (IOException e) {
+            Voicechat.LOGGER.error("Failed to load username cache", e);
+        }
+    }
+
     public void load() {
-        if (!file.exists()) {
+        if (this.appendingFormattedFile.exists()) {
+            this.loadAppending();
+            return;
+        }
+        if (!this.file.exists()) {
             return;
         }
         try (Reader reader = new FileReader(file)) {
             Type usernamesType = new TypeToken<ConcurrentHashMap<UUID, String>>() {
             }.getType();
             names = gson.fromJson(reader, usernamesType);
+            convert();
         } catch (Exception e) {
             Voicechat.LOGGER.error("Failed to load username cache", e);
         }
@@ -50,13 +102,32 @@ public class UsernameCache {
         }
     }
 
-    public synchronized void save() {
-        file.getParentFile().mkdirs();
-        try (Writer writer = new FileWriter(file)) {
-            gson.toJson(names, writer);
-        } catch (Exception e) {
+    public synchronized void saveAppending(UUID uuid, String username) {
+        long t1 = System.nanoTime();
+        appendingFormattedFile.getParentFile().mkdirs();
+        try(FileOutputStream fileOutputStream = new FileOutputStream(this.appendingFormattedFile, true)) {
+            String line = uuid + "#" + username+"\n";
+            fileOutputStream.write(line.getBytes(StandardCharsets.UTF_8));
+        } catch (IOException e) {
             Voicechat.LOGGER.error("Failed to save username cache", e);
         }
+        long t2 = System.nanoTime();
+        Voicechat.LOGGER.debug("saveAppending done in " + (t2-t1)/(1_000_000.0) + " ms");
+    }
+
+    public synchronized void saveMap(Map<UUID, String> mapAppending) {
+        long t1 = System.nanoTime();
+        appendingFormattedFile.getParentFile().mkdirs();
+        try(FileOutputStream fileOutputStream = new FileOutputStream(this.appendingFormattedFile, true)) {
+            for (Map.Entry<UUID, String> uuidStringEntry : mapAppending.entrySet()) {
+                String line = uuidStringEntry.getKey().toString() + "#" + uuidStringEntry.getValue()+"\n";
+                fileOutputStream.write(line.getBytes(StandardCharsets.UTF_8));
+            }
+        } catch (IOException e) {
+            Voicechat.LOGGER.error("Failed to save username cache", e);
+        }
+        long t2 = System.nanoTime();
+        Voicechat.LOGGER.debug("saveMap done in " + (t2-t1)/(1_000_000.0) + " ms, entries: " + (mapAppending.size()));
     }
 
     @Nullable
@@ -76,7 +147,7 @@ public class UsernameCache {
         @Nullable String oldName = names.get(uuid);
         if (!name.equals(oldName)) {
             names.put(uuid, name);
-            SAVE_EXECUTOR_SERVICE.execute(this::save);
+            SAVE_EXECUTOR_SERVICE.execute(() -> saveAppending(uuid, name));
         }
     }
 

--- a/common-client/src/main/java/de/maxhenkel/voicechat/voice/client/ClientPlayerStateManager.java
+++ b/common-client/src/main/java/de/maxhenkel/voicechat/voice/client/ClientPlayerStateManager.java
@@ -21,6 +21,7 @@ import de.maxhenkel.voicechat.plugins.PluginManager;
 import de.maxhenkel.voicechat.plugins.impl.events.ClientVoicechatConnectionEventImpl;
 import de.maxhenkel.voicechat.plugins.impl.events.MicrophoneMuteEventImpl;
 import de.maxhenkel.voicechat.plugins.impl.events.VoicechatDisableEventImpl;
+import de.maxhenkel.voicechat.profile.UsernameCache;
 import de.maxhenkel.voicechat.voice.common.ClientGroup;
 import de.maxhenkel.voicechat.voice.common.PlayerState;
 import net.minecraft.ChatFormatting;
@@ -64,10 +65,16 @@ public class ClientPlayerStateManager {
         ClientServerNetManager.setClientListener(CommonCompatibilityManager.INSTANCE.getNetManager().playerStatesChannel, (player, packet) -> {
             states = packet.getPlayerStates();
             Voicechat.LOGGER.debug("Received {} state(s)", states.size());
+            Map<UUID, String> saveIds = new HashMap<>();
+            UsernameCache usernameCache = VoicechatClient.USERNAME_CACHE;
             for (PlayerState state : states.values()) {
-                VoicechatClient.USERNAME_CACHE.updateUsername(state.getUuid(), state.getName());
+                if(usernameCache.has(state.getUuid())) {
+                    continue;
+                }
+                usernameCache.updateUsername(state.getUuid(), state.getName());
+                saveIds.put(state.getUuid(), state.getName());
             }
-            VoicechatClient.USERNAME_CACHE.save();
+            VoicechatClient.USERNAME_CACHE.saveMap(saveIds);
             AdjustVolumeList.update();
             JoinGroupList.update();
             GroupList.update();


### PR DESCRIPTION
This should increase the overall efficiency of this cache a LOT and reduce the overhead on the client and disk

Basically changes the file from a JSON to a formatted Txt file, where for every new cache entry, we will instead append to the file if it's not existing yet, instead of rewriting our entire cache into the file again, this way, we keep some good efficiency and don't overload the user's system nor cause a spike on resource usage.

Would you merge this?