### PR TITLE
Add notice to EntityAudioChannel

### DIFF
--- a/api/src/main/java/de/maxhenkel/voicechat/api/VoicechatServerApi.java
+++ b/api/src/main/java/de/maxhenkel/voicechat/api/VoicechatServerApi.java
@@ -45,7 +45,7 @@ public interface VoicechatServerApi extends VoicechatApi {
     /**
      * Creates a sound channel for the specified entity.
      *
-     * @param channelId the ID of the channel - Has to be unique
+     * @param channelId the ID of the channel - Has to be the UUID of the entity
      * @param entity    the entity to attach the channel to
      * @return the channel
      */


### PR DESCRIPTION
Just adjust the API docs to tell the dev that the channel id of `createEntityAudioChannel` has to be the same as the UUID of the entity