### PR TITLE
fix: handle audio device errors and refresh secrets on reconnect

### DIFF
--- a/common-client/src/main/java/de/maxhenkel/voicechat/voice/client/SoundManager.java
+++ b/common-client/src/main/java/de/maxhenkel/voicechat/voice/client/SoundManager.java
@@ -90,7 +90,7 @@ public class SoundManager {
         if (l == 0L) {
             throw new SpeakerException("Failed to open audio device: Audio device not found");
         }
-        int error = ALC11.alcGetError(device);
+        int error = ALC11.alcGetError(l);
         if (error != ALC11.ALC_NO_ERROR) {
             if (!ALC11.alcCloseDevice(l)) {
                 Voicechat.LOGGER.warn("Failed to close audio device");

--- a/common/src/main/java/de/maxhenkel/voicechat/voice/server/ServerVoiceEvents.java
+++ b/common/src/main/java/de/maxhenkel/voicechat/voice/server/ServerVoiceEvents.java
@@ -102,6 +102,9 @@ public class ServerVoiceEvents {
         }
         CommonCompatibilityManager.INSTANCE.emitPlayerCompatibilityCheckSucceeded(player);
 
+        // Clear old secrets/connections so re-requests always get a fresh secret
+        server.disconnectClient(player.getUUID());
+
         Secret secret = server.generateNewSecret(player.getUUID());
         if (secret == null) {
             Voicechat.LOGGER.warn("Player already requested secret - ignoring");


### PR DESCRIPTION
This pull request addresses issues in both the client and server components of the voice chat system, focusing on resource handling and connection management. The main improvements ensure proper error checking when opening audio devices and guarantee that player reconnections start with fresh secrets and connections.

Audio device error handling:

* Updated `SoundManager.java` to use the correct device handle (`l`) instead of the device object when checking for errors after opening an audio device, which ensures accurate error detection and handling.

Player connection management:

* Added logic in `ServerVoiceEvents.java` to clear any old secrets and connections for a player before generating a new secret, ensuring that reconnection attempts always use fresh credentials and connections.